### PR TITLE
Document the one-step install

### DIFF
--- a/docs/production-install/README.md
+++ b/docs/production-install/README.md
@@ -13,7 +13,6 @@ Skip this section if you use Agyn Cloud — your platform is already running. Fo
 | Chart | What it deploys |
 |---|---|
 | `agyn-platform` | The control plane — the services behind the API |
-| `agyn-apps` | The workload layer — the runner that executes agents |
 
 Between them you authorize the OpenZiti overlay, sign in, and enroll a runner. That middle step cannot live in a chart: it acts on the OpenZiti controller and on the platform API the first chart has just started. [Install](./install.md) covers all four phases.
 

--- a/docs/production-install/install.md
+++ b/docs/production-install/install.md
@@ -1,23 +1,34 @@
 ---
 title: Helm install
-description: Installing Agyn from the umbrella charts, including the provisioning step between them.
+description: Installing Agyn from one umbrella chart.
 order: 4
 ---
 
 # Helm install
 
-Agyn ships as two umbrella charts, and installing it is **not** two `helm install` commands. Between them sits a provisioning step that acts on things the charts do not own — the OpenZiti controller, and the platform API the first chart has just started.
+Agyn installs as **one Helm chart**: one release, one version, one set of values,
+and no operator step in the middle.
+
+It used to be two charts with a person between them. The runner and the bundled
+apps mount a service token only the running platform can mint, so installing
+them meant signing in, registering each component through the Console, and
+copying credentials shown once into Secrets. The release provisions its own
+resources now, so that step is gone.
 
 | Phase | What it does |
 |---|---|
-| 1. [Prerequisites](#1-prerequisites) | Cluster-level dependencies the charts expect to already exist, plus optional [workload isolation](#workload-isolation-optional-recommended) |
-| 2. [`agyn-platform`](#2-agyn-platform) | The control plane — the services behind the API |
-| 3. [Provisioning](#3-provisioning) | Overlay authorization, then sign in and enroll the runner |
-| 4. [`agyn-apps`](#4-agyn-apps) | The workload layer — the runner that executes agents |
+| 1. [Prerequisites](#1-prerequisites) | Cluster-level dependencies the chart expects to already exist, plus optional [workload isolation](#workload-isolation-optional-recommended) |
+| 2. [`agyn-platform`](#2-agyn-platform) | The platform: control plane, workload layer, and the resources the release declares |
+| 3. [Verify](#3-verify) | What converged, and what to look at when something did not |
 
-Order matters. The overlay must be authorized before the platform can use it, and the runner must be enrolled before `agyn-apps` starts, because the chart mounts a token that step produces.
+There is no ordering to observe. Every precondition provisioning has becomes
+true at a moment the chart cannot predict — a schema migrating inside a
+service's startup, a service self-enrolling onto the overlay, an external
+controller appearing — so nothing is sequenced and anything not yet possible is
+retried. Installing returns once the objects are applied; whether the platform
+is provisioned is a question its objects answer, continuously.
 
-Both charts live at `oci://ghcr.io/agynio/charts`.
+The chart lives at `oci://ghcr.io/agynio/charts`.
 
 ## 1. Prerequisites
 
@@ -31,11 +42,11 @@ By default the runner executes agent workloads with `docker = rootless`: the wor
 
 Do it here, before the platform is running. Installing Kata restarts containerd on each node, so on an empty cluster it costs nothing — on a live one it evicts whatever is already scheduled there.
 
-The runner side is a single value, set later in [phase 4](#4-agyn-apps):
+The runner side is a single value, set in [phase 2](#2-agyn-platform):
 
 | Setting | Value |
 |---|---|
-| `CAPABILITY_IMPLEMENTATIONS` | `{"docker":"kata-fc"}` |
+| `k8s-runner.env` → `CAPABILITY_IMPLEMENTATIONS` | `{"docker":"kata-fc"}` |
 
 The runner stamps `runtimeClassName: kata-fc` on each workload pod, and its RuntimeClass pins those pods to nodes that actually have Kata. Nodes without it simply keep running `rootless` workloads, so a partial rollout is safe.
 
@@ -72,99 +83,51 @@ helm upgrade --install agyn-platform oci://ghcr.io/agynio/charts/agyn-platform \
   -f values-platform.yaml
 ```
 
-This deploys the control plane: gateway, users, organizations, threads, agents, runners, and the rest, plus the namespace workloads will run in (`platform.workloads.namespace`, default `agyn-workloads`).
+This deploys everything: the control plane, the workload layer (the runner and
+the bundled apps), the provisioning controller and the declarations it
+reconciles, plus the namespace workloads run in
+(`platform.workloads.namespace`, default `agyn-workloads`).
+
+**Name your cluster administrators.** This is the one part of the values an
+operator must fill in — a release that declares none installs a platform nobody
+can administer:
+
+```yaml
+provisioning:
+  declarations:
+    clusterAdmins:
+      - address: operator@example.com
+```
 
 Two values deserve attention on an existing install:
 
 - `platform.secretsEncryptionKey.create` — the chart reuses an existing key via `lookup`, but Argo CD renders manifests **without cluster access**, so `lookup` finds nothing and a fresh key is generated. That rotates the key out from under every secret already stored. Set it to `false` when the key is managed elsewhere.
 - `platform.egressCa.create` — same reasoning if your egress CA is provisioned outside the chart.
 
-> **`env` replaces, it does not merge.** Every subchart's `env` list is overridden wholesale. If you set `env` on a service, re-declare **all** of its entries — anything you omit is dropped, including values the chart supplied.
+> **`env` replaces, it does not merge.** Every subchart's `env` list is overridden wholesale. If you set `env` on a service, re-declare **all** of its entries — anything you omit is dropped, including values the chart supplied. `extraEnvVars` is appended rather than replacing, but it cannot override an entry the chart already sets: Helm patches `env` by name and reorders the pair on upgrade, so the chart's value silently wins from then on.
 
-Wait for the control plane to be ready before continuing.
+Installing returns once the objects are applied. Nothing waits, and there is
+nothing to do between this and the next section.
 
-## 3. Provisioning
+## 3. Verify
 
-Only the first step here is unattended. The rest is done from the Console, because enrolling a runner needs a signed-in admin and produces a token shown only once. Nothing here fits in a chart: it acts on the API that phase 2 just started, and on the OpenZiti controller, which the chart does not own. The reference implementation is the two Jobs in [`agynio/bundle-vm`](https://github.com/agynio/bundle-vm) (`deploy/manifests/48-ziti-provision.yaml` and `50-apps-provision.yaml`); a Terraform install does the same with the OpenZiti and Kubernetes providers.
-
-### 3a. Authorize the overlay
-
-OpenZiti denies by default, and an unauthorized service is **invisible rather than refused** — the symptom is `service not found in ziti network`, which reads like a missing object.
-
-Access is granted in two halves and both are required:
-
-| Policy | Grants |
-|---|---|
-| `edge-router-policy` | identities → edge routers |
-| `service-edge-router-policy` | services → edge routers |
-
-With only the service half, a service is authorized but has no router to traverse, reported as `NO_EDGE_ROUTERS_AVAILABLE`. The simplest form is one of each over `#all`.
-
-Then the service policies. Each runner gets its own service at registration, so these are written against **role attributes** rather than names — one rule covers every runner registered in future:
-
-| Policy | Type | Identity roles | Service roles |
-|---|---|---|---|
-| `runners-bind` | Bind | `#runners` | `#runner-services` |
-| `runners-service-dial-runners` | Dial | `#runners-service-hosts` | `#runner-services` |
-| `orchestrators-dial-runners` | Dial | `#orchestrators` | `#runner-services` |
-| `terminal-proxy-dial-runners` | Dial | `#terminal-proxy-hosts` | `#runner-services` |
-
-Add the equivalent Bind/Dial pairs for the platform's own overlay services (`gateway`, `llm-proxy`, `tracing`, app and egress services) as you deploy them. A policy that names a service with `@` fails to apply until that service exists; role-attribute policies are inert until something matches.
-
-### 3b. Become cluster admin
-
-Sign in to the Console. The first account to sign in claims cluster admin — see [First admin](./first-admin.md) — so no credential has to be created by hand.
-
-Set `FIRST_ADMIN_EMAIL` on the Users service before anyone signs in, so the claim is bound to a known address rather than to whoever arrives first. It is honoured only when the IdP marks the address verified; without that, anyone able to register under the operator's address would take the cluster.
-
-The claim is one-shot. It is a single record, so it is not reopened by deleting the admin, or by deleting every admin. If you lose the account, recover through [First admin → Recovery](./first-admin.md#recovery) rather than expecting a second sign-in to grant the role.
-
-### 3c. Enroll the runner
-
-In the Console, with the Cluster Administration context selected: **Runners → Enroll runner**. Give it a name (`k8s-runner`) and optionally labels such as `type=kubernetes`.
-
-The service token is **shown once**, at creation. Copy it before leaving the dialog — it is minted by the Runners service, is the only credential the runner can present, and cannot be regenerated or read back later.
-
-Store it as the secret `agyn-apps` mounts:
+The release declares what the platform should contain, and the provisioning
+controller reconciles it. Progress is per object, so a platform that installed
+without provisioning is visible as objects that are not ready rather than as a
+job whose logs have to be read.
 
 ```sh
-kubectl -n platform create secret generic k8s-runner-service-token \
-  --from-literal=token="$SERVICE_TOKEN"
+kubectl get -n platform organizations,clusteradmins,images,runners,apps,overlaypolicies
 ```
 
-Optionally also create an organization, and an LLM provider and model, if you want the install usable immediately.
+Each carries conditions saying whether it is reconciled, pending, or failing and
+why. `Pending` on a fresh install is ordinary — a service still starting, an
+identity not yet enrolled — and clears on its own.
 
-#### Automating this instead
-
-An install that must complete before any human signs in cannot use the Console, and cannot use the first-admin claim either — spending it on an automation identity leaves no claim for the operator. For that case the gateway accepts a bootstrap credential: set `CLUSTER_ADMIN_TOKEN` and `CLUSTER_ADMIN_IDENTITY_ID`, and write the matching tuple:
-
-```
-user=identity:<CLUSTER_ADMIN_IDENTITY_ID>  relation=admin  object=cluster:global
-```
-
-Then call `RunnersGateway/RegisterRunner` with that token and store the `serviceToken` as above. Point the chart at an existing Secret rather than passing the token by value, so it is not readable by anyone who can read the Deployment. Make the step idempotent by exiting early when the secret already exists.
-
-## 4. `agyn-apps`
-
-```sh
-helm upgrade --install agyn-apps oci://ghcr.io/agynio/charts/agyn-apps \
-  --namespace platform \
-  -f values-apps.yaml
-```
-
-The runner needs, at minimum:
-
-| Setting | Value |
-|---|---|
-| `runners.k8s.enabled` | `true` |
-| `KUBE_NAMESPACE` | the namespace from phase 2 (`agyn-workloads`) |
-| `GATEWAY_ADDRESS` | the gateway service — the platform umbrella overrides its fullname, so the chart default does not resolve |
-| `SERVICE_TOKEN` | from the `k8s-runner-service-token` secret; the runner exits without it once Ziti is enabled |
-| `ZITI_ENABLED` | `true` |
-
-The bundled apps (`reminders`, `telegram-connector`) stay disabled until their databases and app registration are provisioned.
-
-## Verify
+**A declared cluster administrator stays pending until that person first signs
+in.** There is no account to grant against before then; signing in completes the
+declaration rather than triggering it. An install that names none has none —
+nobody is granted the role for arriving first.
 
 ```sh
 # the runner reached the platform

--- a/docs/production-install/install.md
+++ b/docs/production-install/install.md
@@ -124,8 +124,8 @@ Each carries conditions saying whether it is reconciled, pending, or failing and
 why. `Pending` on a fresh install is ordinary — a service still starting, an
 identity not yet enrolled — and clears on its own.
 
-**A declared cluster administrator stays pending until that person first signs
-in.** There is no account to grant against before then; signing in completes the
+**A declared cluster administrator stays pending until that person first signs in.**
+There is no account to grant against before then; signing in completes the
 declaration rather than triggering it. An install that names none has none —
 nobody is granted the role for arriving first.
 

--- a/docs/production-install/uninstall.md
+++ b/docs/production-install/uninstall.md
@@ -6,14 +6,13 @@ order: 5
 
 # Uninstall
 
-Remove the workload layer first, then the control plane:
+Remove the release:
 
 ```sh
-helm uninstall agyn-apps -n platform
 helm uninstall agyn-platform -n platform
 ```
 
-That deletes what the charts created. Everything below outlives them, because the charts did not create it.
+That deletes what the chart created. Provisioned resources are left in place — an organization, image, app or runner is not destroyed by removing its declaration — while cluster administrator grants are revoked. Everything below outlives them, because the charts did not create it.
 
 ## What Helm leaves behind
 

--- a/docs/production-install/upgrades.md
+++ b/docs/production-install/upgrades.md
@@ -11,16 +11,13 @@ An upgrade is a chart version bump:
 ```sh
 helm upgrade agyn-platform oci://ghcr.io/agynio/charts/agyn-platform \
   --version <new> -n platform -f values-platform.yaml
-
-helm upgrade agyn-apps oci://ghcr.io/agynio/charts/agyn-apps \
-  --version <new> -n platform -f values-apps.yaml
 ```
 
-Upgrade `agyn-platform` first: the runner in `agyn-apps` talks to the control plane, not the other way round.
+One release moves everything: the runner and the bundled apps ship in `agyn-platform`, and provisioning re-runs against what the new release declares.
 
 ## Before you upgrade
 
-**Re-read the [prerequisites](./prerequisites.md) when the minor version moves.** A new chart version can bundle a dependency that did not exist before, and bundled dependencies are enabled by default — an upgrade can deploy a second Postgres, or a MinIO that rewrites your object-storage credentials secret, unless your values disable them.
+**Re-read the [prerequisites](./prerequisites.md) when the minor version moves.** A new chart version can bundle a dependency that did not exist before. Every bundled dependency is off unless your values switch it on, so an upgrade will not deploy a second Postgres behind your back — but a dependency you do want still has to be named.
 
 **Check what your values still line up with.** Value paths move between versions. A setting that no longer matches anything is silently ignored rather than rejected, so the symptom is a component quietly reverting to its default.
 


### PR DESCRIPTION
Installing was two charts with a person between them: sign in, authorize the overlay by hand, register the runner through the Console, copy a token shown once into a Secret, then install the second chart. The docs described that sequence in four phases and warned that order mattered.

The release provisions its own resources now, so the sequence is gone. One chart, no operator step inside it, and no ordering to observe — every precondition becomes true at a moment the chart cannot predict, so nothing is sequenced and anything not yet possible is retried.

What replaces the manual phase is a **verification** one: the declarations carry conditions, so a platform that installed without provisioning is visible as objects that are not ready rather than as a job whose logs have to be read. Including the one that surprises people — a declared cluster administrator stays pending until that person first signs in.

Also records the two things an operator now has to know:
- **Naming cluster administrators is the one part of the values they must fill in.** A release that declares none installs a platform nobody can administer.
- **Every bundled dependency is off until they switch it on**, so an upgrade will not deploy a second Postgres behind their back.

Touches `install.md`, `upgrades.md`, `uninstall.md` and the section README. Part of [one-step-install](https://github.com/agynio/architecture/blob/main/changes/2026-08-08-one-step-install.md).