### PR TITLE
Name the overlay .agyn, not .ziti

### DIFF
--- a/docs/build-extend/agent-clis.md
+++ b/docs/build-extend/agent-clis.md
@@ -60,7 +60,7 @@ Inside the runtime container:
 
 1. `/agyn-bin/agynd` is the entrypoint.
 2. `agynd` fetches agent configuration from Gateway (skills → `/skills/*.md`, MCP configs → CLI's MCP config file, init scripts → executed in order).
-3. `agynd` exports `OPENAI_API_BASE` / `ANTHROPIC_API_URL` / equivalents to point at `llm-proxy.ziti` so LLM calls route through the platform proxy.
+3. `agynd` exports `OPENAI_API_BASE` / `ANTHROPIC_API_URL` / equivalents to point at `llm-proxy.agyn` so LLM calls route through the platform proxy.
 4. `agynd` spawns the agent CLI.
 5. The CLI runs its loop. `agynd` posts model output to the thread, acknowledges messages, and sends [keepalives](../administer/agents.md#idle-timeout) while the CLI is producing output.
 

--- a/docs/build-extend/agynd.md
+++ b/docs/build-extend/agynd.md
@@ -20,14 +20,14 @@ The runtime container's image is the dev container you picked when creating the 
 
 ## Startup sequence
 
-1. **Identity.** Read `AGENT_ID` from the environment. The Ziti sidecar already holds the agent's OpenZiti identity — outbound calls to `gateway.ziti` and `llm-proxy.ziti` are mTLS-authenticated transparently.
+1. **Identity.** Read `AGENT_ID` from the environment. The Ziti sidecar already holds the agent's OpenZiti identity — outbound calls to `gateway.agyn` and `llm-proxy.agyn` are mTLS-authenticated transparently.
 2. **Fetch agent configuration.** Call Gateway:
    - `GetAgent` — base configuration.
    - `ListSkills` — written to `/skills/<name>.md`.
    - `ListMCPs` — used to build the agent CLI's MCP config file.
    - `ListInitScripts` — executed in order.
 3. **Run init scripts.** Each script runs in `$WORKSPACE_DIR` (or `/tmp` if unset) with all ENVs available (plain and secret-backed, injected by the orchestrator at workload creation).
-4. **Export LLM endpoint.** Set `OPENAI_API_BASE` / `ANTHROPIC_API_URL` to `http://llm-proxy.ziti:<port>/v1` and supply a synthetic API key. The agent CLI's HTTP client uses this without needing to know about the platform.
+4. **Export LLM endpoint.** Set `OPENAI_API_BASE` / `ANTHROPIC_API_URL` to `http://llm-proxy.agyn:<port>/v1` and supply a synthetic API key. The agent CLI's HTTP client uses this without needing to know about the platform.
 5. **Write MCP config.** For Codex / Claude Code, write the appropriate `mcp.json` or equivalent. For custom CLIs, write a config file at `$AGYND_MCP_CONFIG`.
 6. **Wait for the first unacknowledged message.** Subscribe to `thread_participant:me` notifications via Gateway, then pull the unacknowledged message list with `GetUnackedMessages`.
 7. **Spawn the agent CLI.** Pass the message body via stdin / file (CLI-specific). Stream stdout back as outgoing thread messages.
@@ -70,7 +70,7 @@ All calls go through Gateway over OpenZiti (the Ziti sidecar in the pod). `agynd
 
 ## Tracing proxy
 
-`agynd` runs a small OTLP gRPC proxy on `localhost:4317`. The agent CLI exports spans to this proxy (set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`). The proxy decorates spans with thread, workload, and agent identifiers, then forwards to the Tracing service over `tracing.ziti`.
+`agynd` runs a small OTLP gRPC proxy on `localhost:4317`. The agent CLI exports spans to this proxy (set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`). The proxy decorates spans with thread, workload, and agent identifiers, then forwards to the Tracing service over `tracing.agyn`.
 
 This is how the [Run Timeline](../use/run-timeline.md) gets its data without each agent CLI needing to know the platform's tracing setup.
 

--- a/docs/build-extend/files-mcp.md
+++ b/docs/build-extend/files-mcp.md
@@ -30,7 +30,7 @@ When `agynd` boots an agent that has `files-mcp` attached:
 
 When the agent calls `read_file`:
 
-1. `files-mcp` calls Gateway → Files service over OpenZiti (`gateway.ziti`) authenticated as the agent's identity.
+1. `files-mcp` calls Gateway → Files service over OpenZiti (`gateway.agyn`) authenticated as the agent's identity.
 2. Files service fetches metadata, downloads from S3, returns bytes.
 3. `files-mcp` wraps the bytes in an MCP content block — text for plain text files, image for images, generic resource for binary types — and returns to the agent.
 

--- a/docs/build-extend/mcp-servers.md
+++ b/docs/build-extend/mcp-servers.md
@@ -96,8 +96,8 @@ resource "agyn_agent_mcp" "weather" {
 
 If your MCP needs to call platform services (e.g. it wants to act as the agent on the user's behalf), use the agent's OpenZiti-injected identity. The agent pod has Ziti hostnames available:
 
-- `gateway.ziti` — Gateway API.
-- `llm-proxy.ziti` — LLM Proxy.
+- `gateway.agyn` — Gateway API.
+- `llm-proxy.agyn` — LLM Proxy.
 
 Your MCP container does not need explicit credentials for these — the Ziti sidecar handles mTLS. See [files-mcp](./files-mcp.md) for a working example.
 

--- a/docs/introduction/concepts.md
+++ b/docs/introduction/concepts.md
@@ -73,7 +73,7 @@ These terms have the same meaning everywhere they appear in the product and in t
 | **Workload** | A running agent process — pod + sidecars + volumes — provisioned on a runner. |
 | **Container** | An individual container within a workload, accessible via terminal logs. |
 | **Device** | A user device enrolled into the platform's private network, used to reach exposed services in agent containers. |
-| **Port exposure** | A reachable endpoint for a service running in an agent container. URL form: `http://exposed-<id>.ziti:<port>`. |
+| **Port exposure** | A reachable endpoint for a service running in an agent container. URL form: `http://exposed-<id>.agyn:<port>`. |
 | **Notification** | A real-time event delivered to the UI via WebSocket. Drives live updates for conversations, messages, runs, and tool output. |
 
 ## Apps

--- a/docs/operate/networking.md
+++ b/docs/operate/networking.md
@@ -55,10 +55,10 @@ If you ship your own internal callers (e.g. a custom reconciler), extend the aff
 
 OpenZiti is a zero-trust overlay network. The platform uses it for:
 
-- **Agent workloads** dialing Gateway, LLM Proxy, and Tracing — `gateway.ziti`, `llm-proxy.ziti`, `tracing.ziti`.
+- **Agent workloads** dialing Gateway, LLM Proxy, and Tracing — `gateway.agyn`, `llm-proxy.agyn`, `tracing.agyn`.
 - **Runners** dialed by the Orchestrator over `runner-<id>` services.
 - **Apps** dialing Gateway as themselves.
-- **User devices** reaching exposed services in agent containers via `exposed-<id>.ziti:<port>`.
+- **User devices** reaching exposed services in agent containers via `exposed-<id>.agyn:<port>`.
 
 ### Service naming
 
@@ -99,8 +99,8 @@ The controller credentials are mounted into Ziti Management as a Secret. Rotate 
 
 Apart from the public ingress hostnames, the platform needs:
 
-- **`.ziti` DNS** resolvable inside agent pods. The Ziti sidecar handles this.
-- **`.ziti` DNS** resolvable on enrolled user devices. The Ziti tunnel client handles this.
+- **`.agyn` DNS** resolvable inside agent pods. The Ziti sidecar handles this.
+- **`.agyn` DNS** resolvable on enrolled user devices. The Ziti tunnel client handles this.
 - **In-cluster service DNS** (standard Kubernetes `<service>.<ns>.svc.cluster.local`). Used for service-to-service over Istio.
 
 Public DNS only carries the customer-facing hostnames.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -84,7 +84,7 @@ Same terms as in [Introduction → Concepts](../introduction/concepts.md), plus 
 | **Istio** | Service mesh for in-cluster mTLS and authorization. | [Operate → Networking](../operate/networking.md) |
 | **OpenFGA** | ReBAC engine backing the Authorization service. | [Operate → Authorization](../operate/authorization.md) |
 | **Device** | Personal endpoint enrolled into OpenZiti. | [Use → Devices](../use/devices.md) |
-| **Port exposure** | Reachable endpoint for a service inside an agent container. URL `http://exposed-<id>.ziti:<port>`. | [Use → Port exposure](../use/port-exposure.md) |
+| **Port exposure** | Reachable endpoint for a service inside an agent container. URL `http://exposed-<id>.agyn:<port>`. | [Use → Port exposure](../use/port-exposure.md) |
 | **Notification** | Real-time event delivered to UIs via WebSocket. | [Operate → Architecture](../operate/architecture.md) |
 
 ## Components & repositories

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -12,7 +12,7 @@ Symptoms grouped by where they tend to show up. Start with whichever page matche
 
 - [Install](./install.md) — bootstrap or production install failed, services won't come up.
 - [Authentication / OIDC](./auth-oidc.md) — can't sign in, sign-in loop, claims missing.
-- [Networking / OpenZiti](./networking-ziti.md) — agent can't reach Gateway, `.ziti` hostname fails.
+- [Networking / OpenZiti](./networking-ziti.md) — agent can't reach Gateway, `.agyn` hostname fails.
 - [Agents won't start](./agents.md) — workload fails, init container errors, image pull issues.
 - [LLM calls fail](./llm-calls.md) — auth errors, rate limits, model not found.
 - [MCP tools fail](./mcp-tools.md) — tool returns error, tool not visible to agent.

--- a/docs/troubleshooting/llm-calls.md
+++ b/docs/troubleshooting/llm-calls.md
@@ -70,7 +70,7 @@ This shouldn't happen — `agynd` exports `OPENAI_API_BASE` pointing at LLM Prox
 ## Direct test against LLM Proxy
 
 ```sh
-curl -X POST http://llm-proxy.ziti:8080/v1/responses \
+curl -X POST http://llm-proxy.agyn:8080/v1/responses \
   -H "Authorization: Bearer ignored-by-proxy" \
   -d '{"model": "gpt-4o", "input": "hi"}'
 ```

--- a/docs/troubleshooting/networking-ziti.md
+++ b/docs/troubleshooting/networking-ziti.md
@@ -1,14 +1,14 @@
 ---
 title: Networking / OpenZiti
-description: Agent can't reach Gateway, `.ziti` hostname fails.
+description: Agent can't reach Gateway, `.agyn` hostname fails.
 order: 3
 ---
 
 # Networking / OpenZiti
 
-## Agent pod can't reach Gateway over `gateway.ziti`
+## Agent pod can't reach Gateway over `gateway.agyn`
 
-Symptom: `agynd` logs show `dial tcp: lookup gateway.ziti: no such host` or `connection refused`.
+Symptom: `agynd` logs show `dial tcp: lookup gateway.agyn: no such host` or `connection refused`.
 
 Walk through:
 
@@ -26,11 +26,11 @@ Walk through:
 
 If the Ziti sidecar isn't there at all, the runner is not injecting it. Check the runner's configuration.
 
-## Device can't reach `exposed-<id>.ziti:<port>`
+## Device can't reach `exposed-<id>.agyn:<port>`
 
 1. **Tunnel client running?** `pgrep ziti-edge-tunnel` (Linux) or check Ziti Desktop Edge is signed in.
 2. **Identity enrolled?** In Ziti Desktop Edge, the identity should show as enrolled and connected. In `ziti-edge-tunnel`, check `journalctl -u ziti-edge-tunnel`.
-3. **DNS resolution working?** `dig +short exposed-<id>.ziti`. If empty, the tunnel client isn't routing the hostname; restart it.
+3. **DNS resolution working?** `dig +short exposed-<id>.agyn`. If empty, the tunnel client isn't routing the hostname; restart it.
 4. **Service registered?** The expose service creates an OpenZiti service per exposure. Confirm:
    ```sh
    ziti edge list services --filter 'name contains "exposed-"'
@@ -55,7 +55,7 @@ Symptom: services log `mTLS handshake failure` or `peer not authenticated`.
 
 ## DNS resolution for Ziti hostnames inside agent pods
 
-The Ziti sidecar provides DNS resolution for `.ziti` names. If resolution fails:
+The Ziti sidecar provides DNS resolution for `.agyn` names. If resolution fails:
 
 - The sidecar is not enrolled (see above).
 - The pod's `/etc/resolv.conf` doesn't list the sidecar's DNS first. The runner should configure this — check the pod spec for `dnsConfig`.

--- a/docs/troubleshooting/tracing.md
+++ b/docs/troubleshooting/tracing.md
@@ -13,9 +13,9 @@ The Tracing service captures spans emitted by agents and platform services. If t
 Two possibilities: the run never happened, or the spans never reached Tracing.
 
 - **Did the agent start?** Check Activity → Workloads for the conversation. If there is no workload, the orchestrator never started a run — likely an authorization or scheduling issue (see [Agents won't start](./agents.md)).
-- **Spans not reaching Tracing.** `agynd` runs an OTLP proxy on `localhost:4317` and forwards spans to Tracing over `tracing.ziti`. If either side breaks, the timeline is empty.
+- **Spans not reaching Tracing.** `agynd` runs an OTLP proxy on `localhost:4317` and forwards spans to Tracing over `tracing.agyn`. If either side breaks, the timeline is empty.
   - Check `agynd`'s logs for tracing errors.
-  - Check the Ziti sidecar can resolve `tracing.ziti`.
+  - Check the Ziti sidecar can resolve `tracing.agyn`.
   - Check the Tracing service's ingest metrics.
 
 ## Some events missing

--- a/docs/use/devices.md
+++ b/docs/use/devices.md
@@ -8,7 +8,7 @@ order: 10
 
 A device is a personal endpoint — a laptop, a workstation, a CI runner — enrolled into the platform's OpenZiti overlay network. Enrolled devices can reach services exposed by agent containers (see [Port exposure](./port-exposure.md)).
 
-You enroll devices once. After that, running the Ziti tunnel client on the device gives you access to any `.ziti` URL the platform issues.
+You enroll devices once. After that, running the Ziti tunnel client on the device gives you access to any `.agyn` URL the platform issues.
 
 ## Add a device
 
@@ -39,14 +39,14 @@ sudo ziti-edge-tunnel enroll --jwt /path/to/device.jwt --identity /var/lib/ziti/
 sudo systemctl start ziti-edge-tunnel
 ```
 
-After this, `.ziti` hostnames resolve on the device.
+After this, `.agyn` hostnames resolve on the device.
 
 ## Verify
 
 With the tunnel running, try resolving a known service:
 
 ```sh
-dig +short gateway.ziti
+dig +short gateway.agyn
 ```
 
 A non-empty response means enrollment worked. Without the tunnel running, the hostname will not resolve.
@@ -58,7 +58,7 @@ The Devices page lists every device you have enrolled:
 - **Status** — `pending` (JWT generated, not enrolled) or `enrolled`.
 - **Created** — when the JWT was generated.
 
-You can **revoke** a device — removes its OpenZiti identity. The device loses access to `.ziti` services immediately. Useful for laptops you no longer use or for lost machines.
+You can **revoke** a device — removes its OpenZiti identity. The device loses access to `.agyn` services immediately. Useful for laptops you no longer use or for lost machines.
 
 ## Lost the JWT?
 

--- a/docs/use/port-exposure.md
+++ b/docs/use/port-exposure.md
@@ -12,7 +12,7 @@ The mechanism is simple:
 
 1. You enroll your device into the platform's private network (one time).
 2. The agent runs `agyn expose add <port>` inside its container.
-3. The platform returns a `http://exposed-<id>.ziti:<port>` URL.
+3. The platform returns a `http://exposed-<id>.agyn:<port>` URL.
 4. You open that URL in a browser running on your enrolled device. The Ziti tunnel routes the request to the agent container.
 5. When you're done, the agent runs `agyn expose remove <port>` — or the workload stops, and the exposure is cleaned up automatically.
 
@@ -29,7 +29,7 @@ There is no HTTPS/TLS termination on the exposed URL — exposed services are pl
 ## What you need
 
 1. **An enrolled device.** See [Devices](./devices.md) to add one.
-2. **A Ziti tunnel client** on the device — [Ziti Desktop Edge](https://openziti.io/docs/reference/tunnelers/) on macOS / Windows / Linux, or `ziti-edge-tunnel` on a server. The tunnel client makes `.ziti` hostnames resolvable.
+2. **A Ziti tunnel client** on the device — [Ziti Desktop Edge](https://openziti.io/docs/reference/tunnelers/) on macOS / Windows / Linux, or `ziti-edge-tunnel` on a server. The tunnel client makes `.agyn` hostnames resolvable.
 
 ## Use a port exposure URL
 
@@ -38,7 +38,7 @@ There is no HTTPS/TLS termination on the exposed URL — exposed services are pl
    ```sh
    agyn expose add 3000
    ```
-   The platform responds with a URL like `http://exposed-abc123.ziti:3000`.
+   The platform responds with a URL like `http://exposed-abc123.agyn:3000`.
 3. Open the URL in your browser.
 
 The first time, the browser may take a moment as the Ziti tunnel sets up the connection. Subsequent requests are fast.


### PR DESCRIPTION
Renames the OpenZiti overlay hostnames from `.ziti` to `.agyn`:
`gateway.agyn`, `llm-proxy.agyn`, `tracing.agyn`, and `exposed-<uuid>.agyn`.

The TLD was never a DNS zone — the workload tunneler answers only for
hostnames an `intercept.v1` config names, and forwards everything else
upstream. So this is a naming change, not a networking one.

Not touched: the `ziti` Kubernetes namespace and `*.ziti.svc.cluster.local`,
the `ziti.<domain>` CoreDNS rewrites, and the `ziti-workload-dns` zone keys.

Coordinated across expose, agents-orchestrator, agynd-cli, agyn-cli,
networks, egress, files-mcp, platform-charts, bundle-vm, e2e,
platform-controller and the docs. There is no installed base to migrate.