### PR TITLE
Document cluster admin as declared, not claimed

### DIFF
--- a/docs/administer/cluster-administration.md
+++ b/docs/administer/cluster-administration.md
@@ -6,7 +6,7 @@ order: 2
 
 # Cluster administration
 
-This page covers tasks restricted to cluster admins. Switch to the **Cluster Administration** context in the Console (top-right context switcher) to access these views. If you do not see this context, you do not have the cluster admin role — see [Production installation → First admin](../production-install/first-admin.md).
+This page covers tasks restricted to cluster admins. Switch to the **Cluster Administration** context in the Console (top-right context switcher) to access these views. If you do not see this context, you do not have the cluster admin role — see [Production installation → Cluster administrators](../production-install/first-admin.md).
 
 ## Manage platform users
 
@@ -106,7 +106,7 @@ Apps published as cluster-wide become available to every organization. Most apps
 
 ## Related
 
-- [Production installation → First admin](../production-install/first-admin.md)
+- [Production installation → Cluster administrators](../production-install/first-admin.md)
 - [Runners](./runners.md) — per-org runner registration.
 - [Apps](./apps.md) — per-org app management.
 - [Operate → Identity](../operate/identity.md)

--- a/docs/introduction/choose-your-path.md
+++ b/docs/introduction/choose-your-path.md
@@ -41,7 +41,7 @@ You are a platform operator.
 2. [Production installation → Prerequisites](../production-install/prerequisites.md).
 3. For dev/demo: [Local installation](../local-install/install.md).
 4. For production: [Production installation → Install](../production-install/install.md).
-5. [Production installation → First admin](../production-install/first-admin.md) — claim the cluster admin role.
+5. [Production installation → Cluster administrators](../production-install/first-admin.md) — declare who administers the cluster.
 6. [Operate → Architecture overview](../operate/architecture.md), [Networking](../operate/networking.md), [Identity](../operate/identity.md), [Authorization](../operate/authorization.md).
 7. [Operate → Backup & DR](../operate/backup-disaster-recovery.md), [Upgrades](../operate/upgrades.md), [Security](../operate/security.md).
 

--- a/docs/local-install/install.md
+++ b/docs/local-install/install.md
@@ -47,7 +47,7 @@ If you would rather not touch the system trust store, start with `--no-ca` and a
 
 Open `https://console.agyn.dev:2496/` (or your configured port) and sign in.
 
-The first account provisioned claims cluster admin — see [Production installation → First admin](../production-install/first-admin.md) for how that claim works and why it is one-shot. On a local VM this is simply you.
+Cluster admin is declared, not claimed — see [Production installation → Cluster administrators](../production-install/first-admin.md). On a local VM the bundled account is already declared, so it holds the role from the first sign-in.
 
 ## Configure
 

--- a/docs/production-install/README.md
+++ b/docs/production-install/README.md
@@ -20,7 +20,7 @@ Between them you authorize the OpenZiti overlay, sign in, and enroll a runner. T
 
 - [Prerequisites](./prerequisites.md) — cluster, dependencies, DNS, OIDC.
 - [Install](./install.md) — the four phases, in order.
-- [First admin](./first-admin.md) — how cluster admin is claimed, and how to recover it.
+- [Cluster administrators](./first-admin.md) — how cluster admin is declared, and how to recover it.
 - [Upgrades](./upgrades.md) — moving between chart versions.
 - [Uninstall](./uninstall.md) — removing Agyn cleanly.
 

--- a/docs/production-install/first-admin.md
+++ b/docs/production-install/first-admin.md
@@ -1,20 +1,81 @@
 ---
-title: First admin
-description: How cluster admin is claimed at install, and how to recover it.
+title: Cluster administrators
+description: How cluster admin is declared at install, and how to recover it.
 order: 3
 ---
 
-# First admin
+# Cluster administrators
 
-Nobody creates the first cluster admin: the **first account provisioned** claims the role. The Users service grants it during provisioning, then records the claim.
+Cluster admin is **declared, not claimed**. The install names the people who
+administer it, by the address their identity provider asserts, and the platform
+controller grants the role once an account with that address exists.
 
-## The claim
+Nobody is granted the role for signing in first, and an install that names no
+administrator has none.
 
-`FIRST_ADMIN_EMAIL` narrows who can take it. Leave it unset and whoever signs in first owns the cluster — fine on a laptop, wrong for anything reachable. Set it, and only that address claims the role.
+## Declaring one
 
-A configured address is honoured **only when the IdP marks it verified**. Without that check, anyone able to register under the operator's address would take the cluster. The practical consequence: if your IdP does not send `email_verified`, a configured address can never claim, and no one gets the role.
+Name each administrator under `provisioning.clusterAdmins` in the umbrella
+values:
 
-The claim is **one-shot**. It is a single record, deliberately not tied to the user — deleting the admin does not reopen it, and neither does deleting every admin.
+```yaml
+provisioning:
+  clusterAdmins:
+    - address: operator@example.com
+```
+
+Each entry renders a `ClusterAdmin` object, which the controller reconciles:
+
+```yaml
+apiVersion: platform.agyn.io/v1alpha1
+kind: ClusterAdmin
+spec:
+  address: operator@example.com
+```
+
+The grant is an authorization tuple written through the platform API, so it
+survives a restart and is visible to every service that checks it.
+
+**Removing a declaration revokes the role.** This is the one declaration that
+does not orphan what it created — an unrevokable grant is a hole rather than a
+resource.
+
+## Before the first sign-in
+
+An account exists only after its owner signs in, so a declaration made before
+that has nothing to grant against. It stays pending and is retried:
+
+```console
+$ kubectl -n <namespace> get clusteradmin
+NAME                 ADDRESS                READY   AGE
+admin-278f97081067   operator@example.com   False   2m
+```
+
+```console
+$ kubectl -n <namespace> get clusteradmin admin-278f97081067 \
+    -o jsonpath='{.status.conditions[0].message}'
+no account for "operator@example.com" yet; the grant completes when they first sign in
+```
+
+Signing in completes the declaration rather than triggering it. Ready turns true
+on the next reconcile, and `status.identityIds` records what was granted:
+
+```console
+$ kubectl -n <namespace> get clusteradmin -o wide
+NAME                 ADDRESS                READY   IDENTITIES
+admin-278f97081067   operator@example.com   True    ["1aeb7409-…"]
+```
+
+## When an address names several accounts
+
+`identityIds` is a list because one address can name more than one account. An
+account is keyed on the subject its identity provider asserts, so **changing
+provider leaves the same person holding a new account while the old one still
+carries the address**.
+
+A declaration names a person rather than a row, so it grants to every account
+for the address. The abandoned one keeps a role nothing can authenticate; the
+account the person actually signs into gets what was declared.
 
 ## What the role grants
 
@@ -36,36 +97,61 @@ If it is missing, see [Recovery](#recovery).
 
 ## Create a second admin
 
-Do this early. A single-admin cluster is one lost account away from the recovery procedure below.
+Do this early. A single-admin cluster is one lost account away from the recovery
+procedure below.
 
-Sign in as the existing admin, open Console → **Cluster Administration → Users**, find the second user, and toggle **Cluster Admin** on.
+Either add a second entry to `provisioning.clusterAdmins`, which is the
+reproducible form and survives a reinstall, or — as an existing admin — open
+Console → **Cluster Administration → Users**, find the user and toggle **Cluster
+Admin** on. A role granted through the Console is not written back to the
+declarations, so a rebuilt cluster will not have it.
 
 ## Recovery
 
 ### You signed in but have no admin role
 
-The claim went to another account, or `FIRST_ADMIN_EMAIL` is set and your IdP did not mark the address verified. Confirm the address is verified at the IdP, then grant the role from an existing admin account.
+Check the declaration rather than the account:
+
+```console
+$ kubectl -n <namespace> get clusteradmin -o wide
+```
+
+`Ready=False` names the reason. Pending means no account holds that address yet
+— confirm the address your provider actually asserts matches the one declared,
+which is the usual mismatch. No object at all means the install never declared
+you: add the entry and upgrade.
 
 ### No admin exists at all
 
-Because the claim is one-shot, a later sign-in will not grant it. Grant the role directly:
+Add a declaration and upgrade the release. There is no race to lose and nothing
+one-shot to exhaust — the grant lands as soon as the controller reconciles.
+
+If the platform API is unreachable and the role is needed to repair it, the
+tuple can be written directly as a last resort:
 
 1. Find the user's `identity_id` in the Users service database.
 2. Write the tuple `identity:<identity_id>, admin, cluster:global` to the OpenFGA store.
 3. Restart Authorization.
 
-The role applies on the next page load.
+Prefer the declaration. A tuple written by hand is invisible to
+`provisioning.clusterAdmins`, so nothing revokes it and a rebuilt cluster will
+not reproduce it.
 
 ### Non-interactively
 
-If the install still has a cluster-admin bootstrap credential configured (see [Install → Automating this instead](./install.md#automating-this-instead)), it can be used as a bearer token against the Gateway to grant cluster admin to another identity.
+If the install still has a cluster-admin bootstrap credential configured (see
+[Install → Automating this instead](./install.md#automating-this-instead)), it
+can be used as a bearer token against the Gateway to grant cluster admin to
+another identity. This is the same credential the platform controller presents,
+and it carries the same caveat as writing the tuple by hand: no declaration
+accounts for the result.
 
 ## Hardening
 
-1. Set `FIRST_ADMIN_EMAIL` before the platform is reachable, not after.
-2. Create at least one backup cluster admin.
+1. Declare administrators in the values the install is built from, so a rebuild reproduces them.
+2. Declare at least two, and keep a second account able to sign in.
 3. Remove any bootstrap credential once real admins exist.
-4. Restrict who in your IdP can hold the admin address.
+4. Restrict who in your identity provider can hold a declared address — the address is the whole of the claim, so anyone your provider lets assert it becomes an administrator.
 
 ## Related
 

--- a/docs/production-install/first-admin.md
+++ b/docs/production-install/first-admin.md
@@ -69,9 +69,8 @@ admin-278f97081067   operator@example.com   True    ["1aeb7409-…"]
 ## When an address names several accounts
 
 `identityIds` is a list because one address can name more than one account. An
-account is keyed on the subject its identity provider asserts, so **changing
-provider leaves the same person holding a new account while the old one still
-carries the address**.
+account is keyed on the subject its identity provider asserts.
+**Changing provider leaves the same person holding a new account while the old one still carries the address.**
 
 A declaration names a person rather than a row, so it grants to every account
 for the address. The abandoned one keeps a role nothing can authenticate; the
@@ -102,8 +101,8 @@ procedure below.
 
 Either add a second entry to `provisioning.clusterAdmins`, which is the
 reproducible form and survives a reinstall, or — as an existing admin — open
-Console → **Cluster Administration → Users**, find the user and toggle **Cluster
-Admin** on. A role granted through the Console is not written back to the
+Console → **Cluster Administration → Users**, find the user and toggle
+**Cluster Admin** on. A role granted through the Console is not written back to the
 declarations, so a rebuilt cluster will not have it.
 
 ## Recovery

--- a/docs/production-install/install.md
+++ b/docs/production-install/install.md
@@ -152,12 +152,12 @@ A healthy runner reports `RUNNER_STATUS_ENROLLED`, and its log shows the gRPC se
 | `produced zero addresses` | The named service has no endpoints — usually a component that was never enabled |
 | Empty `OPENFGA_API_URL` | Connection details set on the top-level `openfga` key instead of `platform.openfga` |
 | Files stop authenticating after an upgrade | Bundled MinIO re-created the S3 credentials secret — see `s3.createSecret` |
-| Console shows no Cluster Administration | The first-admin claim went to another account, or `FIRST_ADMIN_EMAIL` is set and the IdP did not mark the address verified (3b) |
+| Console shows no Cluster Administration | No `provisioning.clusterAdmins` entry names the address your IdP asserts, or its `ClusterAdmin` object is not Ready (3b) |
 
 ## Related
 
 - [Prerequisites](./prerequisites.md)
 - [Local installation](../local-install/README.md)
-- [First admin](./first-admin.md)
+- [Cluster administrators](./first-admin.md)
 - [Troubleshooting → Networking & Ziti](../troubleshooting/networking-ziti.md)
 - [Troubleshooting → Auth & OIDC](../troubleshooting/auth-oidc.md)

--- a/docs/production-install/prerequisites.md
+++ b/docs/production-install/prerequisites.md
@@ -52,7 +52,7 @@ An OIDC provider with Authorization Code + PKCE. You need the issuer URL, a clie
 
 If your IdP implements [RFC 8707 resource indicators](https://datatracker.ietf.org/doc/html/rfc8707), the access token is audience-restricted and the OIDC UserInfo endpoint rejects it. The gateway then has to read profile claims from the token itself, and the IdP has to put them there — see [Troubleshooting → Auth & OIDC](../troubleshooting/auth-oidc.md).
 
-For the first sign-in to claim cluster admin reliably, the IdP should also mark the address verified — see [First admin](./first-admin.md).
+The address the IdP asserts is what a cluster admin declaration is matched against, so it has to be the address you declare — see [Cluster administrators](./first-admin.md).
 
 ## Registry access
 
@@ -61,5 +61,5 @@ None. Charts and images are published publicly at `ghcr.io/agynio/*` and pull an
 ## Related
 
 - [Install](./install.md)
-- [First admin](./first-admin.md)
+- [Cluster administrators](./first-admin.md)
 - [Operate → Security](../operate/security.md)

--- a/docs/production-install/uninstall.md
+++ b/docs/production-install/uninstall.md
@@ -52,7 +52,7 @@ Delete `agyn-workloads` only once no agent workloads are still running in it.
 
 ## Partial teardown
 
-To reinstall rather than remove, keep the databases, object storage, and OpenZiti state, and uninstall only the two releases. A reinstall then reconnects to existing data — but note the provisioning step is **not** fully repeatable: the first-admin claim is already spent, and a new runner enrollment mints a new token that must replace the old secret.
+To reinstall rather than remove, keep the databases, object storage, and OpenZiti state, and uninstall only the two releases. A reinstall then reconnects to existing data — but note one part of provisioning is **not** repeatable: a new runner enrollment mints a new token that must replace the old secret. Declared administrators are re-granted on reconcile.
 
 ## Related
 

--- a/docs/production-install/upgrades.md
+++ b/docs/production-install/upgrades.md
@@ -39,7 +39,7 @@ The [provisioning step](./install.md#3-provisioning) is not part of an upgrade:
 
 - Overlay policies persist in the OpenZiti controller.
 - The runner stays enrolled, and its service token stays valid.
-- The first-admin claim is already spent.
+- Administrators are declared, so they are re-granted rather than re-claimed.
 
 ## Read the release notes
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -18,7 +18,7 @@ Same terms as in [Introduction → Concepts](../introduction/concepts.md), plus 
 | **Runner** | Identity that hosts workloads. Cluster- or org-scoped. | [Administer → Runners](../administer/runners.md), [Operate → Runners](../operate/runners.md) |
 | **App** | Independently deployed service that participates in conversations as itself. | [Administer → Apps](../administer/apps.md), [Build & extend → Apps](../build-extend/apps.md) |
 | **Organization** | Multi-tenant boundary grouping users, agents, models, secrets, runners, apps. | [Administer → Organizations](../administer/organizations.md) |
-| **Cluster admin** | Platform-wide administrative role. | [Production installation → First admin](../production-install/first-admin.md), [Administer → Cluster administration](../administer/cluster-administration.md) |
+| **Cluster admin** | Platform-wide administrative role. | [Production installation → Cluster administrators](../production-install/first-admin.md), [Administer → Cluster administration](../administer/cluster-administration.md) |
 | **Organization owner** | Per-organization administrative role. | [Administer → Organizations](../administer/organizations.md) |
 | **Organization member** | Non-owner participant. No Console access. | [Administer → Members](../administer/members.md) |
 | **Agent role** | Per-agent grant: `owner`, `maintainer`, `participant`. | [Administer → Agent roles](../administer/agent-roles.md) |

--- a/docs/troubleshooting/auth-oidc.md
+++ b/docs/troubleshooting/auth-oidc.md
@@ -54,7 +54,19 @@ The user authenticated but has no organization. By design, new users have no acc
 
 ## Cluster admin role missing after first install
 
-See [Production installation → First admin](../production-install/first-admin.md). The bootstrap binds the OIDC subject set in `ADMIN_OIDC_SUBJECT` (default `admin@agyn.io`); if your real IdP issues a different `sub` for you, you won't be cluster admin until you re-apply the `apps` stack with the correct value.
+The role is granted by a declaration matched on the address your IdP asserts, so
+the usual cause is that no declaration names it:
+
+```sh
+kubectl -n <namespace> get clusteradmin -o wide
+```
+
+`Ready=False` with a pending message means no account holds that address yet —
+compare it against the `email` claim your IdP actually sends, which is what the
+match is made on. No object at all means the install declared nobody: add an
+entry to `provisioning.clusterAdmins` and upgrade.
+
+See [Production installation → Cluster administrators](../production-install/first-admin.md).
 
 ## API token authentication fails
 
@@ -78,5 +90,5 @@ The Console and Chat apps store sessions in browser localStorage. If sessions va
 ## Related
 
 - [Operate → Identity](../operate/identity.md)
-- [Production installation → First admin](../production-install/first-admin.md)
+- [Production installation → Cluster administrators](../production-install/first-admin.md)
 - [Use → API tokens](../use/api-tokens.md)


### PR DESCRIPTION
users [#29](https://github.com/agynio/users/pull/29) deleted the one-shot first-admin claim when `provisioning.clusterAdmins` replaced it. The docs kept teaching the mechanism that went away — `FIRST_ADMIN_EMAIL`, the race to sign in first, a claim that could be "spent" — across 10 references in 9 files. Someone following the recovery steps was told to check a variable nothing reads.

`first-admin.md` is rewritten around the declaration: an address is named in the values, the controller grants it once an account with that address exists, and removing the entry revokes it. It keeps its path because eleven links point there; the title is now **Cluster administrators**.

New material for things that had no documentation:

- what the pending state looks like before the first sign-in, and the message it reports
- what happens when an address names more than one account — which is what changing identity provider leaves behind, and what platform-controller 0.2.0 now grants to all of
- why a role granted through the Console or by writing a tuple by hand is not equivalent to declaring it

Also replaces the `ADMIN_OIDC_SUBJECT` advice in the OIDC troubleshooting page, which named a bootstrap Terraform variable rather than anything the platform reads.

**Left alone:** the two `ADMIN_OIDC_SUBJECT` rows in `reference/helm-values.md`. That variable still exists in `bootstrap/apply.sh`, so the rows are accurate for the bootstrap path — but that page also states the umbrella chart "is not in use today", which is no longer true. Worth its own pass alongside the bootstrap deprecation.