### PR TITLE
Refresh the README install story and correct the Terraform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,36 @@ An **open-source, self-hosted alternative** to Google AX, AWS Bedrock AgentCore,
 
 ![Getting Started](getting_started.png)
 
-### Deploy a cluster in 15 minutes
+### On your laptop
+
+The whole platform — control plane, overlay, database, object storage, and a runner — in a VM on your machine. One command, nothing to wire together.
 
 ```bash
-git clone --branch latest https://github.com/agynio/bootstrap.git
-cd bootstrap
-./apply.sh
+brew install agynio/tap/agyn
+agyn local start
 ```
+
+The first run downloads the platform image, so give it a few minutes. It asks once whether to trust the VM's CA, then ends with a link to the console. By then you have a running platform, a profile pointing at it, and a CLI already authenticated against it.
+
+See [Local installation](./docs/local-install/README.md) for prerequisites, flags, and lifecycle commands.
+
+### On your cluster
+
+Production is one Helm release from `oci://ghcr.io/agynio/charts`. The chart deploys the control plane, the workload layer, and the provisioning controller that reconciles the resources the release declares — there is no operator step in the middle.
+
+```bash
+helm upgrade --install agyn-platform oci://ghcr.io/agynio/charts/agyn-platform \
+  --namespace platform --create-namespace \
+  -f values-platform.yaml
+```
+
+Name your cluster administrators in the values — a release that declares none installs a platform nobody can administer. See [Production installation](./docs/production-install/README.md) for prerequisites, DNS and OIDC, optional [Kata/Firecracker workload isolation](./docs/production-install/install.md#workload-isolation-optional-recommended), and upgrades.
+
+### Then
 
 Open the console. Create an org. Deploy your first agent.
 
 Want a ready-made fleet to play with? Apply [`agynio/demo-agent`](https://github.com/agynio/demo-agent) — a Terraform config that provisions a support, marketing, and data-engineer agent in one command.
-
-For production installs, see [Self-host install](./docs/self-host-install/README.md).
 
 ## Define agents as code
 
@@ -71,27 +88,32 @@ Stop clicking. Version your agent infrastructure.
 resource "agyn_agent" "support" {
   organization_id = agyn_organization.acme.id
 
-  name       = "Support"
-  nickname   = "support"
-  model      = agyn_llm_model.gpt_4o.name
-  image      = "ghcr.io/agynio/agent-runtime:v1.0.0"
-  init_image = "ghcr.io/agynio/agent-init-codex:v1.0.0"
+  name     = "Support"
+  nickname = "support"
+  role     = "assistant"
+
+  # The environment supplies the images, compute, and volumes the agent runs with.
+  environment_id = agyn_environment.support.id
+  model          = agyn_model.gpt_4o.id
+  image          = "ghcr.io/agynio/agent-runtime:v1.0.0"
 
   idle_timeout = "5m"
   availability = "internal"
 }
 
-resource "agyn_agent_mcp" "zendesk" {
+resource "agyn_mcp" "zendesk" {
   agent_id = agyn_agent.support.id
   name     = "zendesk"
   image    = "ghcr.io/acme/zendesk-mcp:latest"
+  command  = "zendesk-mcp --port 8080"
+}
 
-  envs = [
-    {
-      name      = "ZENDESK_TOKEN"
-      secret_id = agyn_secret.zendesk_token.id
-    },
-  ]
+# The secret is delivered by reference — its value never enters the state file,
+# and it is injected into the tool that needs it, not into the agent.
+resource "agyn_env" "zendesk_token" {
+  name      = "ZENDESK_TOKEN"
+  mcp_id    = agyn_mcp.zendesk.id
+  secret_id = agyn_secret.zendesk_token.id
 }
 ```
 
@@ -105,8 +127,11 @@ See the [Terraform provider](./docs/build-extend/terraform-provider.md) referenc
 
 - **Serverless runtime** — agents spawn on message, scale to zero on idle. No always-on compute.
 - **Any agent container** — Claude Code, Codex, or your own. No protocol adaptation required.
+- **Environments** — one definition pins the runner, compute flavor, images, volumes, and MCP servers every workload gets. Agents and sandboxes both run them.
 - **MCP servers in separate containers** — each tool gets its own filesystem and process tree. Credentials are injected only into the tool that needs them, never into the agent.
-- **Zero-trust networking** — every agent gets its own x509 identity. Deny-by-default access to internal services.
+- **Egress rules** — the platform attaches credentials to outbound requests at the network edge and denies destinations you have not allowed. The agent calls out with a placeholder; the real token never enters the container.
+- **Zero-trust networking** — every agent gets its own x509 identity. Deny-by-default access to internal services, including private resources inside your VPC or on-prem network without a bastion.
+- **Sandboxes** — an engineer launches the same runtime an agent gets, with a shell in the browser, and drives it by hand. Same image, same secrets, same egress rules.
 - **Declarative config** — define agents and their harness in Terraform. Version-controlled, peer-reviewed, automated.
 - **Observability** — token usage, compute, tracing, activity logs.
 
@@ -125,7 +150,8 @@ Full architecture: [docs/operate/architecture.md](./docs/operate/architecture.md
 Full docs live in [`docs/`](./docs/README.md):
 
 - [Introduction](./docs/introduction/README.md) — what Agyn is, concepts, architecture at a glance.
-- [Self-host install](./docs/self-host-install/README.md) — bootstrap, production install, upgrades.
+- [Local installation](./docs/local-install/README.md) — the whole platform in a VM on your machine.
+- [Production installation](./docs/production-install/README.md) — Helm install, cluster admins, upgrades.
 - [Administer](./docs/administer/README.md) — Console + Terraform for orgs, agents, models, secrets, runners, apps.
 - [Use](./docs/use/README.md) — chat, files, tracing, usage, port exposure.
 - [Build & extend](./docs/build-extend/README.md) — Gateway API, MCP servers, agent CLIs, apps.
@@ -141,13 +167,13 @@ Agyn is split across focused repositories. The most useful starting points:
 |---|---|
 | [`agynio/platform`](https://github.com/agynio/platform) | This repo. Documentation hub. |
 | [`agynio/architecture`](https://github.com/agynio/architecture) | Source-of-truth architecture and product specs. |
-| [`agynio/bootstrap`](https://github.com/agynio/bootstrap) | One-command local install (k3d + Terraform). |
+| [`agynio/bootstrap`](https://github.com/agynio/bootstrap) | Terraform stacks for a k3d dev cluster. For a laptop, prefer `agyn local`. |
 | [`agynio/platform-charts`](https://github.com/agynio/platform-charts) | Production Helm charts. |
 | [`agynio/api`](https://github.com/agynio/api) | Protobuf schemas for every service. |
 | [`agynio/terraform-provider-agyn`](https://github.com/agynio/terraform-provider-agyn) | Terraform provider. |
-| [`agynio/agyn-cli`](https://github.com/agynio/agyn-cli) | Platform CLI. |
-| [`agynio/console-app`](https://github.com/agynio/console-app) · [`chat-app`](https://github.com/agynio/chat-app) · [`tracing-app`](https://github.com/agynio/tracing-app) | Browser UIs. |
-| [`agynio/agent-init-codex`](https://github.com/agynio/agent-init-codex) · [`agent-init-claude`](https://github.com/agynio/agent-init-claude) · [`agent-init-agn`](https://github.com/agynio/agent-init-agn) | Agent CLI init images. |
+| [`agynio/agyn-cli`](https://github.com/agynio/agyn-cli) | Platform CLI — also what `agyn local` runs the platform with. |
+| [`agynio/console-app`](https://github.com/agynio/console-app) · [`chat-app`](https://github.com/agynio/chat-app) · [`tracing-app`](https://github.com/agynio/tracing-app) · [`sandboxes-app`](https://github.com/agynio/sandboxes-app) | Browser UIs. |
+| [`agynio/agyn-runtime-codex`](https://github.com/agynio/agyn-runtime-codex) · [`agyn-runtime-claude`](https://github.com/agynio/agyn-runtime-claude) · [`agyn-runtime-agn`](https://github.com/agynio/agyn-runtime-agn) | Agent runtime images. |
 
 Full list with descriptions: [docs/reference/service-catalog.md](./docs/reference/service-catalog.md).
 

--- a/docs/local-install/README.md
+++ b/docs/local-install/README.md
@@ -22,7 +22,7 @@ A single VM running the same components a production install deploys, sized for 
 
 | | Local | Production |
 |---|---|---|
-| Install | One command | Two charts and a provisioning step between them |
+| Install | One command | One Helm release |
 | Runs on | A VM on your machine | Your Kubernetes cluster |
 | Dependencies | Bundled | Bundled or your own |
 | Ingress | `https://*.agyn.dev:2496` | Your domain and certificates |

--- a/docs/production-install/README.md
+++ b/docs/production-install/README.md
@@ -6,7 +6,7 @@ order: 3
 
 # Production installation
 
-Agyn deploys to your own Kubernetes cluster from two umbrella charts at `oci://ghcr.io/agynio/charts`, with a provisioning step between them.
+Agyn deploys to your own Kubernetes cluster from one umbrella chart at `oci://ghcr.io/agynio/charts`.
 
 Skip this section if you use Agyn Cloud — your platform is already running. For a laptop, see [Local installation](../local-install/README.md) instead.
 
@@ -14,7 +14,7 @@ Skip this section if you use Agyn Cloud — your platform is already running. Fo
 |---|---|
 | `agyn-platform` | The control plane — the services behind the API |
 
-Between them you authorize the OpenZiti overlay, sign in, and enroll a runner. That middle step cannot live in a chart: it acts on the OpenZiti controller and on the platform API the first chart has just started. [Install](./install.md) covers all four phases.
+The release provisions its own resources — the overlay authorization, the runner, and the bundled apps — so there is no operator step in the middle. [Install](./install.md) covers the three phases.
 
 ## Pages
 


### PR DESCRIPTION
The README predated the docs restructure and the one-step install. It pointed at `docs/self-host-install/` — a directory that no longer exists — and offered only the k3d bootstrap path, never mentioning `agyn local start`, the Homebrew tap, or Helm.

## Getting Started → three explicit paths

| | |
|---|---|
| **Laptop** | `brew install agynio/tap/agyn && agyn local start` |
| **Cluster** | one `helm upgrade --install agyn-platform` from `oci://ghcr.io/agynio/charts`, with the cluster-administrator warning and a pointer to optional Kata/Firecracker isolation |
| **Then** | create an org, deploy an agent, or apply the demo fleet |

The laptop path is deliberately two lines: `agyn local start` installs the CA and ends with the console link on its own, so the README doesn't repeat either as a step.

The old "Deploy a cluster in 15 minutes" presented `agynio/bootstrap` as the way in. That repo describes itself as *"Terraform stacks for local k8s cluster bootstrap (k3d)"* — a dev path, now superseded for laptops by `agyn local`. It stays in the repo map, labelled for what it is.

## The Terraform example did not apply

Four identifiers were wrong. Checked against the provider's own generated schema in `terraform-provider-agyn/docs/resources/`:

| Was | Is |
|---|---|
| `agyn_llm_model` | `agyn_model` |
| `agyn_agent_mcp` | `agyn_mcp` |
| `init_image = …` | not in the agent schema — agents take `environment_id` |
| inline `envs = [...]` on an MCP | not an attribute — ENVs are their own `agyn_env` resource |

The `agyn_env` rewrite is also a better story than the old inline block: `mcp_id` + `secret_id` shows credential-by-reference explicitly — the value never enters the state file, and it lands in the tool rather than the agent.

## Documented what shipped but was never described

Added to **How Agyn runs agents**: environments (the definition that pins runner, flavor, images, volumes, and MCPs), egress rules (the actual mechanism behind "credentials never reach the LLM context", which the README asserted without naming), private resources, and sandboxes — a whole surface that was absent.

## Docs pages that contradicted their own install page

`docs/production-install/README.md` said "two umbrella charts… with a provisioning step between them" and "covers all four phases", while its own table listed one chart and `install.md` had already moved to three phases. `docs/local-install/README.md` repeated the two-chart claim in its comparison table. Both aligned with `install.md`.

## Repo map

`agent-init-*` → `agyn-runtime-*` (GitHub redirects, but the names were stale), `sandboxes-app` added to the browser-UI row, and the CLI row notes it is also what `agyn local` runs the platform with.

## Checks

- Every relative link in the README and both touched docs pages resolves — audited, zero broken.
- No `self-host-install`, `agyn_agent_mcp`, `agyn_llm_model`, `init_image`, or `agent-init-` references remain.

## Not done

- `getting_started.png` still shows the old bootstrap flow and probably wants a re-shoot against `agyn local start`.
- The comparison table is unchanged. Kata/Firecracker workload isolation is a differentiator that could earn a row, but I did not want to make competitive claims about other vendors' isolation without checking them.

## Root cause worth noting

The README was last touched 25 June; `docs/` has had eight commits since, including "Document the one-step install" and "docs: remove hooks". Nothing checks the README against the docs it links to, so it drifts silently — a CI link-checker would have caught the `self-host-install` break the day it landed.